### PR TITLE
Add volumes to postgresql services in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=user
       - POSTGRES_DB=ridematefinder
+    volumes:
+      - ./data:/var/lib/postgresql/data
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
- in my macOS setup, everything works correctly with saving data from a PostgreSQL container. I added a step to the docker-compose.yml file specifically, the volumes section, to persist data from the Docker container.